### PR TITLE
Add `Zipper.to_list/1` to return a flattened list

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ a leaf node)
 ### Helper functions
 
 * `Zipper.node/1` returns the zipper's current node
-* `Zipper.lefts` returns a list of the current node's left siblings
-* `Zipper.rights` returns a list of the current node's right siblings
-* `Zipper.path` returns a list of nodes creating a path from the root down to,
+* `Zipper.lefts/1` returns a list of the current node's left siblings
+* `Zipper.rights/1` returns a list of the current node's right siblings
+* `Zipper.path/1` returns a list of nodes creating a path from the root down to,
   but excluding, the current node
+* `Zipper.to_list/1` returns a depth-first walk ordered list of a zipper's elements
 
 * `Zipper.branch?` returns true if the current node is a branch (that is, if it
   can have children, even if it currently does not have any)

--- a/lib/ex_zipper/zipper.ex
+++ b/lib/ex_zipper/zipper.ex
@@ -663,7 +663,28 @@ defmodule ExZipper.Zipper do
     end
   end
 
+  @doc """
+  Returns a flat list of all the elements in the zipper, ordered via a
+  depth-first walk, including the root
+
+  ## Examples
+
+      iex> zipper = Zipper.list_zipper([1,[],[2,3,[4,5]]])
+      iex> Zipper.to_list(zipper)
+      [[1,[],[2,3,[4,5]]], 1, [], [2,3,[4,5]], 2, 3, [4,5], 4, 5]
+
+  """
+  @spec to_list(Zipper.t) :: [any()]
+  def to_list(zipper = %__MODULE__{}), do: _to_list(zipper, [])
+
   ## Private
+
+  defp _to_list(zipper, acc) do
+    case end?(zipper) do
+      true -> Enum.reverse(acc)
+      false -> _to_list(next(zipper), [__MODULE__.node(zipper)|acc])
+    end
+  end
 
   defp recur_prev(zipper = %__MODULE__{}) do
     case down(zipper) do

--- a/test/ex_zipper/zipper/list_test.exs
+++ b/test/ex_zipper/zipper/list_test.exs
@@ -497,8 +497,7 @@ defmodule ExZipper.Zipper.ListTest do
       assert Zipper.remove(context.zipper) == {:error, :remove_root}
     end
 
-    test "removes the current focus, and moves to the prev location in a depth-first walk",
-         context do
+    test "removes the current focus, and moves to the prev location in a depth-first walk", context do
       zipper = Zipper.down(context.zipper)
       zipper = Zipper.remove(zipper)
       assert zipper.focus == [[], 2, [3, 4, [5, 6], [7]], 8]
@@ -513,6 +512,26 @@ defmodule ExZipper.Zipper.ListTest do
       assert zipper.focus == 3
       zipper = Zipper.root(zipper)
       assert zipper.focus == [1, [], 2, [3, [5, 6], [7]], 8]
+    end
+  end
+
+  describe "to_list" do
+    test "returns a depth-first list of all elements in the zipper", context do
+      assert Zipper.to_list(context.zipper) == [
+        [1, [], 2, [3, 4, [5, 6], [7]], 8],
+        1,
+        [],
+        2,
+        [3, 4, [5, 6], [7]],
+        3,
+        4,
+        [5,6],
+        5,
+        6,
+        [7],
+        7,
+        8
+      ]
     end
   end
 end

--- a/test/ex_zipper/zipper/struct_test.exs
+++ b/test/ex_zipper/zipper/struct_test.exs
@@ -960,4 +960,26 @@ defmodule ExZipper.Zipper.StructTest do
              }
     end
   end
+
+  describe "to_list" do
+    test "returns a depth-first list of all elements in the zipper", context do
+      zipper_list = Z.to_list(context.zipper)
+      assert length(zipper_list) == 13
+      assert Enum.map(zipper_list, &(&1.__struct__)) == [
+        Measure,
+        Note,
+        Voice,
+        Note,
+        Voice,
+        Note,
+        Note,
+        Voice,
+        Note,
+        Note,
+        Voice,
+        Note,
+        Note
+      ]
+    end
+  end
 end


### PR DESCRIPTION
of depth-first-ordered elements.                                                                              