### PR TITLE
Upgrade stream data and relax restriction

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule ExZipper.Mixfile do
     {:credo, github: "rrrene/credo", only: [:dev, :test], runtime: false},
     {:mix_test_watch, "~> 0.5.0", only: :dev, runtime: false},
     {:ex_doc, "~> 0.18.1", only: [:dev, :test], runtime: false},
-    {:stream_data, "~> 0.3.0"}
+    {:stream_data, "~> 0.3", only: [:test]}
   ]
 
   # ------------------------------------------------------------

--- a/mix.lock
+++ b/mix.lock
@@ -8,5 +8,5 @@
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
   "mix_test_watch": {:hex, :mix_test_watch, "0.5.0", "2c322d119a4795c3431380fca2bca5afa4dc07324bd3c0b9f6b2efbdd99f5ed3", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
-  "stream_data": {:hex, :stream_data, "0.3.0", "cbfc8e3212f64683615657ea27804126a42ded634adfdfee258bf087ee605d46", [:mix], []},
+  "stream_data": {:hex, :stream_data, "0.4.2", "fa86b78c88ec4eaa482c0891350fcc23f19a79059a687760ddcf8680aac2799b", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
This allows you to use ex_zipper in a project when you want to use stream_data 0.4.0